### PR TITLE
Handle and pass Exceptions to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,22 @@ api_instance = mparticle.EventsApi(configuration)
 # synchronous
 try: 
     api_instance.upload_events(batch)
-    #or api_instance.bulk_upload_events([batch_1, batch_2])
+    # or api_instance.bulk_upload_events([batch_1, batch_2])
+    # both upload and bulk_upload also have _with_http_info signatures,
+    # which will return the HTTP status info and headers, along with the body
 except mparticle.rest.ApiException as e:
     print "Exception while calling mParticle: %s\n" % e
 
 
 # asynchronous, specifying your callback function
-# api_instance.upload_events(batch, callback=callback_function)
+def my_callback(response):
+    if type(response) is mparticle.rest.ApiException:
+        print 'An error occured: ' + str(response)
+    else:
+        #successful uploads will yield an HTTP 202 response and no body
+        print response
+        
+thread = api_instance.upload_events(batch, callback=my_callback)
 ```
 
 ### License

--- a/mparticle/api_client.py
+++ b/mparticle/api_client.py
@@ -152,10 +152,17 @@ class ApiClient(object):
         url = self.host + resource_path
 
         # perform request and return response
-        response_data = self.request(method, url,
-                                     query_params=query_params,
-                                     headers=header_params,
-                                     post_params=post_params, body=body)
+        try:
+            response_data = self.request(method, url,
+                                         query_params=query_params,
+                                         headers=header_params,
+                                         post_params=post_params, body=body)
+        except Exception as api_exception:
+            if callback:
+                callback(api_exception)
+                return
+            else:
+                raise
 
         self.last_response = response_data
 


### PR DESCRIPTION
This makes it so when the api client is used asynchronously, `Exceptions`
can be handled more gracefully, without crashing the api thread, as in the following example:

``` python
def my_callback(response):
    if type(response) is mparticle.rest.ApiException:
        print 'An error occured: ' + str(response)
    else:
        #successful uploads will yield an HTTP 202 response and no body
        print response

thread = api_instance.upload_events(batch, callback=my_callback)
```
