### PR TITLE
Hotfix/other ids

### DIFF
--- a/mparticle/api_client.py
+++ b/mparticle/api_client.py
@@ -89,7 +89,7 @@ class ApiClient(object):
             self.host = host
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'mParticle Python client/0.10.4'
+        self.user_agent = 'mParticle Python client/0.10.5'
 
     @property
     def user_agent(self):

--- a/mparticle/models/user_identities.py
+++ b/mparticle/models/user_identities.py
@@ -29,7 +29,7 @@ import re
 
 class UserIdentities(object):
 
-    def __init__(self, other=None, customerid=None, facebook=None, twitter=None, google=None, microsoft=None, yahoo=None, email=None, alias=None, facebook_custom_audience_id=None, other_2=None, other_3=None, other_4=None):
+    def __init__(self, other=None, customerid=None, facebook=None, twitter=None, google=None, microsoft=None, yahoo=None, email=None, alias=None, facebook_custom_audience_id=None, other2=None, other3=None, other4=None):
         """
         UserIdentities - a model defined in Swagger
 
@@ -49,9 +49,9 @@ class UserIdentities(object):
             'email': 'str',
             'alias': 'str',
             'facebook_custom_audience_id': 'str',
-            'other_2': 'str',
-            'other_3': 'str',
-            'other_4': 'str'
+            'other2': 'str',
+            'other3': 'str',
+            'other4': 'str'
         }
 
         self.attribute_map = {
@@ -65,9 +65,9 @@ class UserIdentities(object):
             'email': 'email',
             'alias': 'alias',
             'facebook_custom_audience_id': 'facebook_custom_audience_id',
-            'other_2': 'other_2',
-            'other_3': 'other_3',
-            'other_4': 'other_4'
+            'other2': 'other2',
+            'other3': 'other3',
+            'other4': 'other4'
         }
 
         self._other = other
@@ -80,9 +80,9 @@ class UserIdentities(object):
         self._email = email
         self._alias = alias
         self._facebook_custom_audience_id = facebook_custom_audience_id
-        self._other_2 = other_2
-        self._other_3 = other_3
-        self._other_4 = other_4
+        self._other2 = other2
+        self._other3 = other3
+        self._other4 = other4
 
     @property
     def other(self):
@@ -315,74 +315,74 @@ class UserIdentities(object):
         self._facebook_custom_audience_id = facebook_custom_audience_id
 
     @property
-    def other_2(self):
+    def other2(self):
         """
-        Gets the other_2 of this UserIdentities.
+        Gets the other2 of this UserIdentities.
 
 
-        :return: The other_2 of this UserIdentities.
+        :return: The other2 of this UserIdentities.
         :rtype: str
         """
-        return self._other_2
+        return self._other2
 
-    @other_2.setter
-    def other_2(self, other_2):
+    @other2.setter
+    def other2(self, other2):
         """
-        Sets the other_2 of this UserIdentities.
+        Sets the other2 of this UserIdentities.
 
 
-        :param other_2: The other_2 of this UserIdentities.
+        :param other2: The other2 of this UserIdentities.
         :type: str
         """
 
-        self._other_2 = other_2
+        self._other2 = other2
 
     @property
-    def other_3(self):
+    def other3(self):
         """
-        Gets the other_3 of this UserIdentities.
+        Gets the other3 of this UserIdentities.
 
 
-        :return: The other_3 of this UserIdentities.
+        :return: The other3 of this UserIdentities.
         :rtype: str
         """
-        return self._other_3
+        return self._other3
 
-    @other_3.setter
-    def other_3(self, other_3):
+    @other3.setter
+    def other3(self, other3):
         """
-        Sets the other_3 of this UserIdentities.
+        Sets the other3 of this UserIdentities.
 
 
-        :param other_3: The other_3 of this UserIdentities.
+        :param other3: The other3 of this UserIdentities.
         :type: str
         """
 
-        self._other_3 = other_3
+        self._other3 = other3
 
 
     @property
-    def other_4(self):
+    def other4(self):
         """
-        Gets the other_4 of this UserIdentities.
+        Gets the other4 of this UserIdentities.
 
 
-        :return: The other_4 of this UserIdentities.
+        :return: The other4 of this UserIdentities.
         :rtype: str
         """
-        return self._other_4
+        return self._other4
 
-    @other_4.setter
-    def other_4(self, other_4):
+    @other4.setter
+    def other4(self, other4):
         """
-        Sets the other_4 of this UserIdentities.
+        Sets the other4 of this UserIdentities.
 
 
-        :param other_4: The other_4 of this UserIdentities.
+        :param other4: The other4 of this UserIdentities.
         :type: str
         """
 
-        self._other_4 = other_4
+        self._other4 = other4
 
     def to_dict(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "mparticle"
-VERSION = "0.10.4"
+VERSION = "0.10.5"
 
 
 

--- a/test/test_user_identities.py
+++ b/test/test_user_identities.py
@@ -46,20 +46,20 @@ class TestUserIdentities(unittest.TestCase):
         model = mparticle.models.user_identities.UserIdentities()
 
     def testOtherUserIdentitiesConstructor(self):
-        model = mparticle.models.user_identities.UserIdentities(other_2="foo-other2", other_3="foo-other3", other_4="foo-other4")
-        self.assertEqual("foo-other2", model.other_2)
-        self.assertEqual("foo-other3", model.other_3)
-        self.assertEqual("foo-other4", model.other_4)
+        model = mparticle.models.user_identities.UserIdentities(other2="foo-other2", other3="foo-other3", other4="foo-other4")
+        self.assertEqual("foo-other2", model.other2)
+        self.assertEqual("foo-other3", model.other3)
+        self.assertEqual("foo-other4", model.other4)
 
 
     def testOtherUserIdentitiesProperties(self):
         model = mparticle.models.user_identities.UserIdentities()
-        model.other_2 = "foo-other2"
-        model.other_3 = "foo-other3"
-        model.other_4 = "foo-other4"
-        self.assertEqual("foo-other2", model.other_2)
-        self.assertEqual("foo-other3", model.other_3)
-        self.assertEqual("foo-other4", model.other_4)
+        model.other2 = "foo-other2"
+        model.other3 = "foo-other3"
+        model.other4 = "foo-other4"
+        self.assertEqual("foo-other2", model.other2)
+        self.assertEqual("foo-other3", model.other3)
+        self.assertEqual("foo-other4", model.other4)
 
     def testOtherUserIdentitiesSerialization(self):
         model = mparticle.models.user_identities.UserIdentities()
@@ -67,13 +67,13 @@ class TestUserIdentities(unittest.TestCase):
         for key in identity_dict:
             self.assertEqual(None, identity_dict[key])
 
-        model.other_2 = "foo-other2"
-        model.other_3 = "foo-other3"
-        model.other_4 = "foo-other4"
+        model.other2 = "foo-other2"
+        model.other3 = "foo-other3"
+        model.other4 = "foo-other4"
         identity_dict = model.to_dict()
-        self.assertEqual("foo-other2", identity_dict["other_2"])
-        self.assertEqual("foo-other3", identity_dict["other_3"])
-        self.assertEqual("foo-other4", identity_dict["other_4"])
+        self.assertEqual("foo-other2", identity_dict["other2"])
+        self.assertEqual("foo-other3", identity_dict["other3"])
+        self.assertEqual("foo-other4", identity_dict["other4"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The original deploy was coded to the incorrect internal DTO. The correct external DTO does not include underscores in the other identity types.

This has been manually tested against a production environment and the unit tests have been updated.