### PR TITLE
fix: Reimplement 429 handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the mParticle Python client SDK - use it to send your data to the [mPart
 
 ### Requirements.
 
-Python 2.7 and later.
+Python 3.5 and later.
 
 ### Installation
 

--- a/mparticle/apis/events_api.py
+++ b/mparticle/apis/events_api.py
@@ -24,20 +24,11 @@
 
 from __future__ import absolute_import
 
-import sys
-import os
-import re
-import calendar
-import time
-
 # python 2 and python 3 compatibility library
 from six import iteritems
 
 from ..configuration import Configuration
 from ..api_client import ApiClient
-
-retryAfterTimestamp = calendar.timegm(time.gmtime())
-latestResponse = None
 
 class EventsApi(object):
 
@@ -137,25 +128,17 @@ class EventsApi(object):
         # Authentication setting
         auth_settings = ['basic']
 
-        if retryAfterTimestamp > calendar.timegm(time.gmtime()):
-            return latestResponse
-
-        latestResponse = self.api_client.call_api(resource_path, 'POST',
-                                            path_params,
-                                            query_params,
-                                            header_params,
-                                            body=body_params,
-                                            post_params=form_params,
-                                            files=local_var_files,
-                                            response_type=None,
-                                            auth_settings=auth_settings,
-                                            callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
-        
-        retry_after = latestResponse.getheader("Retry-After")
-        if retry_after:
-            retryAfterTimestamp = calendar.timegm(time.gmtime()) + retry_after
-        return latestResponse
+        return self.api_client.call_api(resource_path, 'POST',
+                                        path_params,
+                                        query_params,
+                                        header_params,
+                                        body=body_params,
+                                        post_params=form_params,
+                                        files=local_var_files,
+                                        response_type=None,
+                                        auth_settings=auth_settings,
+                                        callback=params.get('callback'),
+                                        _return_http_data_only=params.get('_return_http_data_only'))
 
     def upload_events(self, body, **kwargs):
         """
@@ -248,22 +231,14 @@ class EventsApi(object):
         # Authentication setting
         auth_settings = ['basic']
 
-        if retryAfterTimestamp > calendar.timegm(time.gmtime()):
-            return latestResponse
-
-        latestResponse = self.api_client.call_api(resource_path, 'POST',
-                                            path_params,
-                                            query_params,
-                                            header_params,
-                                            body=body_params,
-                                            post_params=form_params,
-                                            files=local_var_files,
-                                            response_type=None,
-                                            auth_settings=auth_settings,
-                                            callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
-        
-        retry_after = latestResponse.getheader("Retry-After")
-        if retry_after:
-            retryAfterTimestamp = calendar.timegm(time.gmtime()) + retry_after
-        return latestResponse
+        return self.api_client.call_api(resource_path, 'POST',
+                                        path_params,
+                                        query_params,
+                                        header_params,
+                                        body=body_params,
+                                        post_params=form_params,
+                                        files=local_var_files,
+                                        response_type=None,
+                                        auth_settings=auth_settings,
+                                        callback=params.get('callback'),
+                                        _return_http_data_only=params.get('_return_http_data_only'))


### PR DESCRIPTION
## Summary
- Reimplement 429 handling at a lower level as required by the http library we're using

## Testing Plan
- Tested using a small Node.js server that returns 429 responses

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4354