### PR TITLE
Support timestamp and decimal types in sanitize_for_serialization

### DIFF
--- a/mparticle/api_client.py
+++ b/mparticle/api_client.py
@@ -36,6 +36,7 @@ import threading
 from datetime import datetime
 from datetime import date
 from datetime import time
+from decimal import Decimal
 
 # python 2 and python 3 compatibility library
 from six import iteritems
@@ -206,6 +207,8 @@ class ApiClient(object):
         If obj is str, int, long, float, bool, return directly.
         If obj is datetime.datetime, datetime.date, datetime.time
             convert to string in iso8601 format.
+        if obj is decimal.Decimal
+            convert to string
         If obj is list, sanitize each element in the list.
         If obj is dict, return the dict.
         If obj is swagger model, return the properties dict.
@@ -223,6 +226,8 @@ class ApiClient(object):
                     for sub_obj in obj]
         elif isinstance(obj, (datetime, date, time)):
             return obj.isoformat()
+        elif isinstance(obj, Decimal):
+            return str(obj)
         else:
             if isinstance(obj, dict):
                 obj_dict = obj

--- a/mparticle/api_client.py
+++ b/mparticle/api_client.py
@@ -35,6 +35,7 @@ import threading
 
 from datetime import datetime
 from datetime import date
+from datetime import time
 
 # python 2 and python 3 compatibility library
 from six import iteritems
@@ -203,7 +204,7 @@ class ApiClient(object):
 
         If obj is None, return None.
         If obj is str, int, long, float, bool, return directly.
-        If obj is datetime.datetime, datetime.date
+        If obj is datetime.datetime, datetime.date, datetime.time
             convert to string in iso8601 format.
         If obj is list, sanitize each element in the list.
         If obj is dict, return the dict.
@@ -220,7 +221,7 @@ class ApiClient(object):
         elif isinstance(obj, list):
             return [ApiClient.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
-        elif isinstance(obj, (datetime, date)):
+        elif isinstance(obj, (datetime, date, time)):
             return obj.isoformat()
         else:
             if isinstance(obj, dict):

--- a/test/test_api_client.py
+++ b/test/test_api_client.py
@@ -24,6 +24,9 @@
 
 from __future__ import absolute_import
 
+import datetime
+import decimal
+import json
 import os
 import sys
 import unittest
@@ -46,6 +49,52 @@ class TestApiClient(unittest.TestCase):
         self.assertFalse(ApiClient.validate_attribute_bag_values({"foo":"bar", "foo-2":5, "foo-3":[3.14], "foo-4":None}))
         pass
 
+    def test_sanitize_for_serialization(self):
+        obj = {
+            "a_string": "foo",
+            "a_int": 123,
+            "a_float": 1.23,
+            "a_bool": True,
+            "a_null": None,
+            "a_date": datetime.date(2023, 5, 3),
+            "a_datetime": datetime.datetime(2023, 5, 3, 10, 58, 16, 123),
+            "a_time": datetime.time(10, 58, 16, 123),
+            "a_decimal": decimal.Decimal('5.2E+7'),
+            "a_dict": {
+                "a_string": "foo",
+                "a_int": 123,
+            },
+            "a_array": [
+                "hello",
+                "world",
+            ],
+        }
+
+        sanitized_obj = ApiClient.sanitize_for_serialization(obj)
+        assert sanitized_obj == {
+            "a_string": "foo",
+            "a_int": 123,
+            "a_float": 1.23,
+            "a_bool": True,
+            "a_null": None,
+            "a_date": '2023-05-03',
+            "a_datetime": '2023-05-03T10:58:16.000123',
+            "a_time": '10:58:16.000123',
+            "a_decimal": '5.2E+7',
+            "a_dict": {
+                "a_string": "foo",
+                "a_int": 123,
+            },
+            "a_array": [
+                "hello",
+                "world",
+            ],
+        }
+
+        serialized_obj = json.dumps(sanitized_obj)
+        assert serialized_obj == '{"a_string": "foo", "a_int": 123, "a_float": 1.23, "a_bool": true, "a_null": null, ' \
+                                 '"a_date": "2023-05-03", "a_datetime": "2023-05-03T10:58:16.000123", "a_time": "10:58:16.000123", ' \
+                                 '"a_decimal": "5.2E+7", "a_dict": {"a_string": "foo", "a_int": 123}, "a_array": ["hello", "world"]}'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 ## Summary

Added support for timestamps (as isoformat) and decimals (as strings) in sanitize_for_serialization

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - I tested using unit tests, by building a json object and checking the resulting output
 - I ran a data pipeline using the altered code and verified the output
 
 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDDI-5382
