### PR TITLE
Add integration attributes to sdk

### DIFF
--- a/docs/Batch.md
+++ b/docs/Batch.md
@@ -16,6 +16,7 @@
 | **deleted_user_attributes** | **list[str]**                                           |             | [optional] |
 | **user_identities**         | [**UserIdentities**](UserIdentities.md)                 |             | [optional] |
 | **consentState**            | [**ConsentState**](ConsentState.md)                     |             | [optional] |
+| **integration_attributes**  | **dict(str, dict(str, str))**                           |             | [optional] |
 | **mpid**                    | **int**                                                 |             | [optional] |
 | **mp_deviceid**             | **str**                                                 |             | [optional] |
 

--- a/example_usage.py
+++ b/example_usage.py
@@ -43,6 +43,12 @@ consent_state.gdpr = {'document_agreement': gdpr_consent_state}
 
 batch.consent_state = consent_state
 
+batch.integration_attributes = {
+  "123": {
+    "someIntegrationAttribute":"value"
+  }
+}
+
 app_event = mparticle.AppEvent('Example', 'navigation')
 app_event.timestamp_unixtime_ms = 1552596256103
 app_event.custom_flags = {

--- a/mparticle/models/batch.py
+++ b/mparticle/models/batch.py
@@ -63,7 +63,7 @@ from .user_attribute_change_event import UserAttributeChangeEvent
 
 class Batch(object):
 
-    def __init__(self, events=None, source_request_id=None, environment=None, ip=None, schema_version=None, device_info=None, application_info=None, user_attributes=None, deleted_user_attributes=None, user_identities=None, api_key=None, mpid=None, mp_deviceid=None, consent_state=None, context=None):
+    def __init__(self, events=None, source_request_id=None, environment=None, ip=None, schema_version=None, device_info=None, application_info=None, user_attributes=None, deleted_user_attributes=None, user_identities=None, api_key=None, mpid=None, mp_deviceid=None, consent_state=None, context=None, integration_attributes=None):
         """
         Batch - a model defined in Swagger
 
@@ -84,6 +84,7 @@ class Batch(object):
             'deleted_user_attributes': 'list[str]',
             'user_identities': 'UserIdentities',
             'consent_state': 'ConsentState',
+            'integration_attributes': 'dict(str, dict(str, str))',
             'api_key': 'str',
             'mpid': 'int',
             'mp_deviceid': 'str',
@@ -102,6 +103,7 @@ class Batch(object):
             'deleted_user_attributes': 'deleted_user_attributes',
             'user_identities': 'user_identities',
             'consent_state': 'consent_state',
+            'integration_attributes': 'integration_attributes',
             'api_key': 'api_key',
             'mpid': 'mpid',
             'mp_deviceid': 'mp_deviceid',
@@ -118,6 +120,7 @@ class Batch(object):
         self._application_info = application_info
         self._user_attributes = user_attributes
         self._consent_state = consent_state
+        self._integration_attributes = integration_attributes
         self._deleted_user_attributes = deleted_user_attributes
         self._user_identities = user_identities
         self._mpid = mpid
@@ -486,6 +489,27 @@ class Batch(object):
 
         self._consent_state = consent_state
 
+    @property
+    def integration_attributes(self):
+        """Gets the integration_attributes of this Batch.  # noqa: E501
+
+
+        :return: The integration_attributes of this Batch.  # noqa: E501
+        :rtype: dict(str, dict(str, str))
+        """
+        return self._integration_attributes
+
+    @integration_attributes.setter
+    def integration_attributes(self, integration_attributes):
+        """Sets the integration_attributes of this Batch.
+
+
+        :param integration_attributes: The integration_attributes of this Batch.  # noqa: E501
+        :type: dict(str, dict(str, str))
+        """
+
+        self._integration_attributes = integration_attributes
+        
     @property
     def context(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "mparticle"
-VERSION = "0.16.0"
+VERSION = "0.16.1"
 
 
 # To install the library, run the following

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -91,5 +91,19 @@ class TestBatch(unittest.TestCase):
         self.assertEqual("foo", batch_dict["context"]["data_plan"]["plan_id"])
         self.assertEqual(5, batch_dict["context"]["data_plan"]["plan_version"])
 
+    def testBatchIntegrationAttributes(self):
+        """
+        Test Batch Integration Attributes
+        """
+        model = mparticle.models.batch.Batch()
+
+        identity_dict = model.to_dict()
+        for key in identity_dict:
+            self.assertEqual(None, identity_dict[key])
+
+        model.integration_attributes = { "123": { "someIntegrationAttribute": "value" } }
+        identity_dict = model.to_dict()
+        self.assertEqual({ "123": { "someIntegrationAttribute":"value" } }, identity_dict["mpid"])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 ## Summary
Added support for integration attributes in case they are needed to be included using the Python SDK

 ## Testing Plan
 - [X] Was this tested locally? 
 - I tested using unit tests, by asigning a dictionary with the [proper structure](https://docs.mparticle.com/developers/server/json-reference/#integration_attributes) to the batch object and checking the resulting output when it is assigned
 - I've sent some batches via Custom Feed using the Python SDK and verified the proper integration attributes appear on the batch in Livestream

